### PR TITLE
Add optional environment paramter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 account_guid = "ACT-123" # str | The unique identifier for an `account`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.

--- a/atrium/api/atrium_client.py
+++ b/atrium/api/atrium_client.py
@@ -8,19 +8,20 @@ import six
 import atrium
 
 class AtriumClient(object):
-    def __init__(self, api_key, client_id):
+    def __init__(self, api_key, client_id, environment = "https://vestibule.mx.com"):
         configuration = atrium.Configuration()
         configuration.headers['MX-API-Key'] = api_key
         configuration.headers['MX-Client-ID'] = client_id
+        configuration.host = environment
         
-        self.accounts = atrium.AccountsApi()
-        self.connect_widget = atrium.ConnectWidgetApi()
-        self.holdings = atrium.HoldingsApi()
-        self.identity = atrium.IdentityApi()
-        self.institutions = atrium.InstitutionsApi()
-        self.members = atrium.MembersApi()
-        self.merchants = atrium.MerchantsApi()
-        self.statements = atrium.StatementsApi()
-        self.transactions = atrium.TransactionsApi()
-        self.users = atrium.UsersApi()
-        self.verification = atrium.VerificationApi()
+        self.accounts = atrium.AccountsApi(atrium.ApiClient(configuration))
+        self.connect_widget = atrium.ConnectWidgetApi(atrium.ApiClient(configuration))
+        self.holdings = atrium.HoldingsApi(atrium.ApiClient(configuration))
+        self.identity = atrium.IdentityApi(atrium.ApiClient(configuration))
+        self.institutions = atrium.InstitutionsApi(atrium.ApiClient(configuration))
+        self.members = atrium.MembersApi(atrium.ApiClient(configuration))
+        self.merchants = atrium.MerchantsApi(atrium.ApiClient(configuration))
+        self.statements = atrium.StatementsApi(atrium.ApiClient(configuration))
+        self.transactions = atrium.TransactionsApi(atrium.ApiClient(configuration))
+        self.users = atrium.UsersApi(atrium.ApiClient(configuration))
+        self.verification = atrium.VerificationApi(atrium.ApiClient(configuration))

--- a/atrium/api_client.py
+++ b/atrium/api_client.py
@@ -59,7 +59,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'MX-Codegen/2.7.0/python'
+        self.user_agent = 'MX-Codegen/2.8.0/python'
 
     def __del__(self):
         self.pool.close()

--- a/atrium/configuration.py
+++ b/atrium/configuration.py
@@ -240,5 +240,5 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: 0.1\n"\
-               "SDK Package Version: 2.7.0".\
+               "SDK Package Version: 2.8.0".\
                format(env=sys.platform, pyversion=sys.version)

--- a/docs/AccountsApi.md
+++ b/docs/AccountsApi.md
@@ -24,7 +24,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 account_guid = "ACT-123" # str | The unique identifier for an `account`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -74,7 +74,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 user_guid = "USR-123" # str | The unique identifier for a `user`.
 page = 1 # int | Specify current page. (optional)
@@ -118,7 +118,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 account_guid = "ACT-123" # str | The unique identifier for an `account`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -160,7 +160,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 account_guid = "ACT-123" # str | The unique identifier for an `account`.
 member_guid = "MBR-123" # str | The unique identifier for a `member`.

--- a/docs/ConnectWidgetApi.md
+++ b/docs/ConnectWidgetApi.md
@@ -21,7 +21,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 user_guid = "USR-123" # str | The unique identifier for a `user`.
 body = atrium.ConnectWidgetRequestBody() # ConnectWidgetRequestBody | Optional config options for WebView (is_mobile_webview, current_institution_code, current_member_guid, update_credentials)

--- a/docs/HoldingsApi.md
+++ b/docs/HoldingsApi.md
@@ -24,7 +24,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 user_guid = "USR-123" # str | The unique identifier for a `user`.
 
@@ -64,7 +64,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 account_guid = "ACT-123" # str | The unique identifier for an `account`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -106,7 +106,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -148,7 +148,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 holding_guid = "HOL-123" # str | The unique identifier for a `holding`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.

--- a/docs/IdentityApi.md
+++ b/docs/IdentityApi.md
@@ -22,7 +22,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -64,7 +64,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.

--- a/docs/InstitutionsApi.md
+++ b/docs/InstitutionsApi.md
@@ -23,7 +23,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 name = name_example # str | This will list only institutions in which the appended string appears. (optional)
 page = 1 # int | Specify current page. (optional)
@@ -75,7 +75,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 institution_code = "example_institution_code" # str | The institution_code of the institution.
 
@@ -115,7 +115,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 institution_code = "example_institution_code" # str | The institution_code of the institution.
 

--- a/docs/MembersApi.md
+++ b/docs/MembersApi.md
@@ -33,7 +33,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -75,7 +75,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 user_guid = "USR-123" # str | The unique identifier for a `user`.
 body = atrium.MemberCreateRequestBody() # MemberCreateRequestBody | Member object to be created with optional parameters (identifier and metadata) and required parameters (credentials and institution_code)
@@ -117,7 +117,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -158,7 +158,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -200,7 +200,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -246,7 +246,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -288,7 +288,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -330,7 +330,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -380,7 +380,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 user_guid = "USR-123" # str | The unique identifier for a `user`.
 page = 1 # int | Specify current page. (optional)
@@ -424,7 +424,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -466,7 +466,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -508,7 +508,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -552,7 +552,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.

--- a/docs/MerchantsApi.md
+++ b/docs/MerchantsApi.md
@@ -21,7 +21,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 merchant_guid = "MCH-123" # str | The unique identifier for a `merchant`.
 

--- a/docs/StatementsApi.md
+++ b/docs/StatementsApi.md
@@ -24,7 +24,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -68,7 +68,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -110,7 +110,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -156,7 +156,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.

--- a/docs/TransactionsApi.md
+++ b/docs/TransactionsApi.md
@@ -23,7 +23,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 body = atrium.TransactionsCleanseAndCategorizeRequestBody() # TransactionsCleanseAndCategorizeRequestBody | User object to be created with optional parameters (amount, type) amd required parameters (description, identifier)
 
@@ -63,7 +63,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 user_guid = "USR-123" # str | The unique identifier for a `user`.
 page = 1 # int | Specify current page. (optional)
@@ -111,7 +111,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 transaction_guid = "TRN-123" # str | The unique identifier for a `transaction`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.

--- a/docs/UsersApi.md
+++ b/docs/UsersApi.md
@@ -25,7 +25,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 body = atrium.UserCreateRequestBody() # UserCreateRequestBody | User object to be created with optional parameters (identifier, is_disabled, metadata)
 
@@ -65,7 +65,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 user_guid = "USR-123" # str | The unique identifier for a `user`.
 
@@ -104,7 +104,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 page = 1 # int | Specify current page. (optional)
 records_per_page = 12 # int | Specify records per page. (optional)
@@ -146,7 +146,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 user_guid = "USR-123" # str | The unique identifier for a `user`.
 
@@ -186,7 +186,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 user_guid = "USR-123" # str | The unique identifier for a `user`.
 body = atrium.UserUpdateRequestBody() # UserUpdateRequestBody | User object to be updated with optional parameters (identifier, is_disabled, metadata) (optional)

--- a/docs/VerificationApi.md
+++ b/docs/VerificationApi.md
@@ -23,7 +23,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -65,7 +65,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 account_guid = "ACT-123" # str | The unique identifier for an `account`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.
@@ -107,7 +107,7 @@ from atrium.rest import ApiException
 from pprint import pprint
 
 # create an instance of the AtriumClient
-client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID")
+client = atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com")
 
 member_guid = "MBR-123" # str | The unique identifier for a `member`.
 user_guid = "USR-123" # str | The unique identifier for a `user`.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "atrium"
-VERSION = "2.7.0"
+VERSION = "2.8.0"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
Adds an optional environment parameter when creating the AtriumClient so
developers can easily switch to production environment. If optional
parameter is omitted, environment defaults to development (vestibule).