### PR TITLE
add proxy support

### DIFF
--- a/atrium/api/atrium_client.py
+++ b/atrium/api/atrium_client.py
@@ -8,12 +8,25 @@ import six
 import atrium
 
 class AtriumClient(object):
-    def __init__(self, api_key, client_id, environment = "https://vestibule.mx.com"):
+    def __init__(
+        self,
+        api_key,
+        client_id,
+        environment="https://vestibule.mx.com",
+        proxy=None,
+        proxy_user=None,
+        proxy_pass=None,
+        proxy_headers=None
+    ):
         configuration = atrium.Configuration()
         configuration.headers['MX-API-Key'] = api_key
         configuration.headers['MX-Client-ID'] = client_id
         configuration.host = environment
-        
+        configuration.proxy = proxy
+        configuration.proxy_user = proxy_user
+        configuration.proxy_pass = proxy_pass
+        configuration.proxy_headers = proxy_headers
+
         self.accounts = atrium.AccountsApi(atrium.ApiClient(configuration))
         self.connect_widget = atrium.ConnectWidgetApi(atrium.ApiClient(configuration))
         self.holdings = atrium.HoldingsApi(atrium.ApiClient(configuration))

--- a/atrium/configuration.py
+++ b/atrium/configuration.py
@@ -88,6 +88,9 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
 
         # Proxy URL
         self.proxy = None
+        self.proxy_user = None
+        self.proxy_pass = None
+        self.proxy_headers = None
         # Safe chars for path_param
         self.safe_chars_for_path_param = ''
 

--- a/atrium/rest.py
+++ b/atrium/rest.py
@@ -80,6 +80,16 @@ class RESTClientObject(object):
 
         # https pool manager
         if configuration.proxy:
+
+            if configuration.proxy_headers:
+                proxy_headers = configuration.proxy_headers
+            elif (configuration.proxy_user and configuration.proxy_pass):
+                proxy_headers = urllib3.make_headers(
+                    proxy_basic_auth=f'{configuration.proxy_user}:{configuration.proxy_pass}'  # noqa: E501
+                )
+            else:
+                proxy_headers = None
+
             self.pool_manager = urllib3.ProxyManager(
                 num_pools=pools_size,
                 maxsize=maxsize,
@@ -88,6 +98,7 @@ class RESTClientObject(object):
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 proxy_url=configuration.proxy,
+                proxy_headers=proxy_headers,
                 **addition_pool_args
             )
         else:


### PR DESCRIPTION
MX Atrium requires whitelisted addresses for successful contact. Serverless architecture provided by  some platforms (eg. GCP) make this difficult to achieve without routing requests through an external proxy.

`atrium-python` was already built to consider a proxy URL, but the option was not easily exposed to the user.

Upon instantiating the client, the user may provide their proxy URL and credentials if necessary. Upon doing so, the user has the option to create their own proxy authentication headers, or allow them to be built on their behalf within urllib3.